### PR TITLE
Fix missing bus replacement route (Z61) for KM R61 train

### DIFF
--- a/data/routes.yaml
+++ b/data/routes.yaml
@@ -309,7 +309,7 @@ agencies:
         long_name: "Warszawa — Małkinia"
         color: "008800"
       - id: "KM_R61"
-        match: [{short_name: "*R61*"}]
+        match: [{short_name: "*R61*"}, {short_name: "*Z61*"}]
         short_name: "R61"
         long_name: "Tłuszcz — Ostrołęka"
         color: "008800"


### PR DESCRIPTION
### Problem

Route curation was failing because the bus replacement route for KM_R61 wasn't defined.

### Fix
Added missing short_name for this route:
```
  - id: "KM_R61"
    match: [{short_name: "*R61*"}, {short_name: "*Z61*"}]
    short_name: "R61"
    long_name: "Tłuszcz — Ostrołęka"
    color: "008800"
```

### Testing
After adding this entry the static GTFS generates successfully.
```
[INFO 20:23:04.904] Task.SaveGTFS: Dumping tables
[INFO 20:23:06.289] Task.SaveGTFS: Compressing to polish_trains.zip
[INFO 20:23:08.228] Pipeline: All tasks finished
```


**Side note**
Perhaps bus replacement routes should be added for all KM trains preemptively since they seem to be following the same naming syntax and there already is a couple of them?