### PR TITLE
Improved alerts

### DIFF
--- a/polish_trains_gtfs/realtime/cmd/main.go
+++ b/polish_trains_gtfs/realtime/cmd/main.go
@@ -29,13 +29,14 @@ import (
 )
 
 var (
-	flagAlerts      = flag.Bool("alerts", false, "parse disruptions instead of operations")
+	flagAlerts      = flag.Bool("alerts", false, "include disruptions (alerts)")
 	flagAlternative = flag.Duration("alternative", 20*time.Minute, "when non-zero, fetch fresh schedules from API")
 	flagClients     = flag.String("clients", "", "path to JSON client configuration file")
 	flagGTFS        = flag.String("gtfs", "polish_trains.zip", "path to GTFS Schedule feed")
 	flagLoop        = flag.Duration("loop", 0, "when non-zero, update the feed continuously with the given period")
 	flagOutput      = flag.String("output", "polish_trains.pb", "path to output .pb file")
 	flagReadable    = flag.Bool("readable", false, "dump output in human-readable format")
+	flagUpdates     = flag.Bool("updates", true, "include operations (trip updates)")
 	flagVerbose     = flag.Bool("verbose", false, "show DEBUG logging")
 )
 
@@ -45,6 +46,9 @@ var clientPool *client.Pool
 
 func main() {
 	flag.Parse()
+	if !*flagAlerts && !*flagUpdates {
+		log.Fatal("At least one of -alerts or -updates must be enabled")
+	}
 	if *flagVerbose {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
@@ -119,17 +123,40 @@ func run(static *schedules.Package) (int, match.Stats, error) {
 }
 
 func fetch(static *schedules.Package, client *client.Client) (*fact.Container, match.Stats, error) {
-	if *flagAlerts {
-		return fetchAlerts(static, client)
+	var stats match.Stats
+	var facts *fact.Container
+
+	if *flagUpdates {
+		uFacts, uStats, err := fetchUpdates(static, client)
+		if err != nil {
+			return nil, uStats, err
+		}
+		facts = uFacts
+		stats.Add(uStats)
 	}
-	return fetchUpdates(static, client)
+
+	if *flagAlerts {
+		aFacts, aStats, err := fetchAlerts(static, client)
+		if err != nil {
+			return nil, aStats, err
+		}
+		stats.Add(aStats)
+
+		if facts == nil {
+			facts = aFacts
+		} else {
+			facts.Alerts = aFacts.Alerts
+		}
+	}
+
+	return facts, stats, nil
 }
 
 func fetchAlerts(static *schedules.Package, client *client.Client) (*fact.Container, match.Stats, error) {
 	var stats match.Stats
 
 	slog.Debug("Fetching disruptions")
-	real, err := source.FetchDisruptions(context.Background(), client.Key, client)
+	real, err := source.FetchDisruptions(context.Background(), client.Key, client, static.Dates.Start, static.Dates.End)
 	if err != nil {
 		return nil, stats, err
 	}

--- a/polish_trains_gtfs/realtime/match/alert.go
+++ b/polish_trains_gtfs/realtime/match/alert.go
@@ -5,6 +5,7 @@ package match
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/MKuranowski/PolishTrainsGTFS/polish_trains_gtfs/realtime/fact"
 	"github.com/MKuranowski/PolishTrainsGTFS/polish_trains_gtfs/realtime/schedules"
@@ -19,14 +20,14 @@ func Alerts(real *source.Disruptions, static *schedules.Package, stats *Stats) *
 		Alerts:    make([]*fact.Alert, 0, len(real.Disruptions)),
 	}
 	for _, d := range real.Disruptions {
-		if a := Alert(d, static, stats); a != nil {
+		if a := Alert(d, static, stats, real.DisruptionTypes); a != nil {
 			c.Alerts = append(c.Alerts, a)
 		}
 	}
 	return c
 }
 
-func Alert(real *source.Disruption, static *schedules.Package, stats *Stats) *fact.Alert {
+func Alert(real *source.Disruption, static *schedules.Package, stats *Stats, disruptionTypes map[string]string) *fact.Alert {
 	// Try to match the trains
 	trips := make([]fact.TripSelector, 0, len(real.AffectedTrains))
 	for _, train := range real.AffectedTrains {
@@ -47,6 +48,11 @@ func Alert(real *source.Disruption, static *schedules.Package, stats *Stats) *fa
 	// Bail out when no trains match
 	if len(trips) == 0 {
 		return nil
+	}
+
+	// PDP-API uses codes like 'utr_1' in message field when message has no placeholders. Replace them with actual messages.
+	if strings.Contains(real.Message, "utr_") {
+		real.Message = disruptionTypes[real.Message]
 	}
 
 	// Convert the alert

--- a/polish_trains_gtfs/realtime/match/stats.go
+++ b/polish_trains_gtfs/realtime/match/stats.go
@@ -16,3 +16,9 @@ func (s Stats) String() string {
 	percentMatched := 100 * float64(s.Matched) / float64(total)
 	return fmt.Sprintf("matched %d / %d (%.2f %%), rejected %d outside of feed dates", s.Matched, total, percentMatched, s.OutsideFeedDates)
 }
+
+func (s *Stats) Add(o Stats) {
+	s.Matched += o.Matched
+	s.Unmatched += o.Unmatched
+	s.OutsideFeedDates += o.OutsideFeedDates
+}

--- a/polish_trains_gtfs/realtime/source/disruption.go
+++ b/polish_trains_gtfs/realtime/source/disruption.go
@@ -6,14 +6,17 @@ package source
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/MKuranowski/PolishTrainsGTFS/polish_trains_gtfs/realtime/util/http2"
+	"github.com/MKuranowski/PolishTrainsGTFS/polish_trains_gtfs/realtime/util/time2"
 )
 
 type Disruptions struct {
-	Timestamp   time.Time     `json:"ts"`
-	Disruptions []*Disruption `json:"ds"`
+	Timestamp       time.Time         `json:"ts"`
+	Disruptions     []*Disruption     `json:"ds"`
+	DisruptionTypes map[string]string `json:"dt"`
 }
 
 type Disruption struct {
@@ -30,12 +33,18 @@ type AffectedTrain struct {
 	Sequence  int `json:"seq"`
 }
 
-func FetchDisruptions(ctx context.Context, apikey string, client http2.Doer) (d *Disruptions, err error) {
+func FetchDisruptions(ctx context.Context, apikey string, client http2.Doer, dateFrom, dateTo time2.Date) (d *Disruptions, err error) {
+	query := url.Values{
+		"dateFrom": {dateFrom.String()},
+		"dateTo":   {dateTo.String()},
+	}
+
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://pdp-api.plk-sa.pl/api/v1/disruptions/shortened", nil)
 	if err != nil {
 		return
 	}
 	req.Header.Set("X-Api-Key", apikey)
+	req.URL.RawQuery = query.Encode()
 
 	return http2.GetJSON[Disruptions](client, req)
 }


### PR DESCRIPTION
Improve alerts generation by:
- changing the flag behaviour to enable including both trip updates and alerts in a single feed. (The go app consumes quite a lot RAM, so running two instances with identical lookup table seems wasteful)
- querying alerts for all dates covered by feed
- replacing alert messages like `utr_1` with their human readable text, based on the mapping.

Explanation of the last bullet: PDP-API returns `disruption _code` in `message` field for disruptions whose text has no placeholders. Conveniently, a dictionary of those code is provided under `dt` (`disruptionTypes`). This PR proposes to use this dictionary to translate those codes into human readable text.

Future work: each affected train has `stationId`, which _could_ be used to further specify the alert, by ex. expanding the text to `{station}: {message}` (but some messages already contain the station names), by adding the stationId to the TripSelector (but support for that in consuming applications seems limited) or by adding it to title (as it is always empty in API data). Also, a mapping for cause/efffect could be provided based on messages (as they seem to be mostly a static set of used messages).