### PR TITLE
Use towards on ZKA stops

### DIFF
--- a/polish_trains_gtfs/static/load_bus_stops.py
+++ b/polish_trains_gtfs/static/load_bus_stops.py
@@ -37,9 +37,12 @@ class BusStop:
     lat: float = 0.0
     lon: float = 0.0
     direction_hints: list[str] = field(default_factory=list[str])
+    towards: list[str] = field(default_factory=list[str])
 
     @property
     def gtfs_id(self) -> str:
+        if self.towards != []:
+            return f"{self.station_id}_BUS_{self.towards[0]}"
         if self.direction_hints == [] or self.direction_hints == ["*"]:
             return f"{self.station_id}_BUS"
         return f"{self.station_id}_BUS_{self.direction_hints[0]}"
@@ -65,6 +68,8 @@ class PLRailMapBusStopLoader(XmlSaxContentHandler):
                 self.current_stop.station_id = attrs["v"]
             elif attrs["k"] == "direction" and attrs["v"]:
                 self.current_stop.direction_hints = attrs["v"].split(";")
+            elif attrs["k"] == "towards" and attrs["v"]:
+                self.current_stop.towards = attrs["v"].split(";")
 
     def endElement(self, name: str) -> None:
         if name == "node":
@@ -279,6 +284,9 @@ class GeoTripMatcher:
         self.stop_id_by_hint = {
             hint: stop.gtfs_id for stop in bus_stops for hint in stop.direction_hints
         }
+        self.stop_id_by_towards = {
+            towards: stop.gtfs_id for stop in bus_stops for towards in stop.towards
+        }
         self.match_cache = dict[tuple[str | None, str, str | None], str]()
         self.used_ids = set[str]()
 
@@ -287,7 +295,9 @@ class GeoTripMatcher:
         curr_id = trip.stop_times[stop_time_offset].id
         next_id = st.id if (st := list_get(trip.stop_times, stop_time_offset + 1)) else None
 
-        if (replacement_id := self.match_cache.get((prev_id, curr_id, next_id))) is None:
+        if (
+            replacement_id := self.match_cache.get((prev_id, curr_id, next_id))
+        ) is None:
             replacement_id = self.match_inner(prev_id, curr_id, next_id)
             self.match_cache[(prev_id, curr_id, next_id)] = replacement_id
             self.used_ids.add(replacement_id)
@@ -300,6 +310,9 @@ class GeoTripMatcher:
 
         if star_id := self.stop_id_by_hint.get("*"):
             return star_id
+
+        if next_id and (towards_id := self.stop_id_by_towards.get(next_id)):
+            return towards_id
 
         trip_bearing = self.calc_bearing(prev_id, curr_id, next_id)
         closest_hint = min(

--- a/polish_trains_gtfs/static/load_bus_stops.py
+++ b/polish_trains_gtfs/static/load_bus_stops.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from itertools import groupby
+from math import inf
 from operator import itemgetter
 from statistics import mean
 from typing import Self, cast
@@ -14,7 +15,7 @@ from xml.sax.xmlreader import AttributesImpl as XmlSaxAttributes
 
 from impuls import DBConnection, Task, TaskRuntime
 from impuls.model import Stop
-from impuls.tools.geo import initial_bearing
+from impuls.tools.geo import earth_distance_m, initial_bearing
 from impuls.tools.types import StrPath
 
 from .util import json
@@ -256,12 +257,23 @@ class LoadBusStops(Task):
                 ),
             )
         elif len(new_stops) > 1:
-            lat = round(mean(i.lat for i in new_stops), 6)
-            lon = round(mean(i.lon for i in new_stops), 6)
-            db.raw_execute(
-                "UPDATE stops SET lat = ?, lon = ?, location_type = 1 WHERE stop_id = ?",
-                (lat, lon, station_id),
-            )
+            # Move the station location only if the bus stops are not spread geographically.
+            # When they are spread apart quite far, the station pin is likely to land in the
+            # middle of nowhere, in some very random place. It's better to keep it at the original
+            # station's location.
+            if bbox_diagonal_dist(new_stops) <= 500:
+                lat = round(mean(i.lat for i in new_stops), 6)
+                lon = round(mean(i.lon for i in new_stops), 6)
+                db.raw_execute(
+                    "UPDATE stops SET lat = ?, lon = ?, location_type = 1 WHERE stop_id = ?",
+                    (lat, lon, station_id),
+                )
+            else:
+                db.raw_execute(
+                    "UPDATE stops SET location_type = 1 WHERE stop_id = ?",
+                    (station_id,),
+                )
+
             db.raw_execute_many(
                 "INSERT INTO stops (stop_id,name,lat,lon,parent_station) VALUES (?,?,?,?,?)",
                 ((i.gtfs_id, existing_stop.name, i.lat, i.lon, station_id) for i in new_stops),
@@ -348,6 +360,24 @@ def has_train_departures(db: DBConnection, stop_id: str) -> bool:
         (stop_id,),
     ) as q:
         return q.one() is not None
+
+
+def bbox_diagonal_dist(stops: Iterable[BusStop]) -> float:
+    min_lat = inf
+    min_lon = inf
+    max_lat = -inf
+    max_lon = -inf
+
+    for stop in stops:
+        min_lat = min(min_lat, stop.lat)
+        min_lon = min(min_lon, stop.lon)
+        max_lat = max(max_lat, stop.lat)
+        max_lon = max(max_lon, stop.lon)
+
+    if min_lat == inf:
+        return 0  # no stops
+
+    return earth_distance_m(min_lat, min_lon, max_lat, max_lon)
 
 
 def list_get[T, U](seq: Sequence[T], idx: int, default: U = None) -> T | U:

--- a/polish_trains_gtfs/static/load_bus_stops.py
+++ b/polish_trains_gtfs/static/load_bus_stops.py
@@ -295,24 +295,22 @@ class GeoTripMatcher:
         curr_id = trip.stop_times[stop_time_offset].id
         next_id = st.id if (st := list_get(trip.stop_times, stop_time_offset + 1)) else None
 
-        if (
-            replacement_id := self.match_cache.get((prev_id, curr_id, next_id))
-        ) is None:
+        if (replacement_id := self.match_cache.get((prev_id, curr_id, next_id))) is None:
             replacement_id = self.match_inner(prev_id, curr_id, next_id)
             self.match_cache[(prev_id, curr_id, next_id)] = replacement_id
             self.used_ids.add(replacement_id)
         return StopUpdate.for_trip(trip, stop_time_offset, replacement_id)
 
     def match_inner(self, prev_id: str | None, curr_id: str, next_id: str | None) -> str:
+        if next_id and (towards_id := self.stop_id_by_towards.get(next_id)):
+            return towards_id
+
         terminates = not prev_id or not next_id
         if terminates and (terminus_id := self.stop_id_by_hint.get("T")):
             return terminus_id
 
         if star_id := self.stop_id_by_hint.get("*"):
             return star_id
-
-        if next_id and (towards_id := self.stop_id_by_towards.get(next_id)):
-            return towards_id
 
         trip_bearing = self.calc_bearing(prev_id, curr_id, next_id)
         closest_hint = min(

--- a/polish_trains_gtfs/static/load_bus_stops.py
+++ b/polish_trains_gtfs/static/load_bus_stops.py
@@ -41,11 +41,11 @@ class BusStop:
 
     @property
     def gtfs_id(self) -> str:
-        if self.towards != []:
+        if self.direction_hints and self.direction_hints != ["*"]:
+            return f"{self.station_id}_BUS_{self.direction_hints[0]}"
+        if self.towards:
             return f"{self.station_id}_BUS_{self.towards[0]}"
-        if self.direction_hints == [] or self.direction_hints == ["*"]:
-            return f"{self.station_id}_BUS"
-        return f"{self.station_id}_BUS_{self.direction_hints[0]}"
+        return f"{self.station_id}_BUS"
 
     def __bool__(self) -> bool:
         return self.station_id != "" and self.lat != 0.0 and self.lon != 0.0


### PR DESCRIPTION
Use `towards` tag on ZKA stops, based on next station of the trip.
Matching by `towards` takes priority over `directions` and when no stop is found using the `towards` stops taged by directions are considered.

Complimentary change in PlRailMap: https://github.com/MKuranowski/PLRailMap/pull/6