### PR TITLE
Set pickup/dropoff type to 1 when no departure/arrival time is available

### DIFF
--- a/polish_trains_gtfs/static/load_schedules.py
+++ b/polish_trains_gtfs/static/load_schedules.py
@@ -160,7 +160,7 @@ class LoadSchedules(Task):
         route_stations = cast(list[json.Object], r.get("st", []))
         route_stations.sort(key=itemgetter("ord"))
         for i, route_station in enumerate(route_stations):
-            self.process_route_stop(db, trip_id, i, route_station)
+            self.process_route_stop(db, trip_id, i, route_station, i == 0, i == len(route_stations) - 1)
 
     def process_route_stop(
         self,
@@ -168,12 +168,11 @@ class LoadSchedules(Task):
         trip_id: str,
         sequence: int,
         s: json.Object,
+        is_first_stop: bool,
+        is_last_stop: bool,
     ) -> None:
         stop_id = self.get_stop_id(db, s["id"])
         plk_sequence = cast(int, s["ord"])
-
-        pickup_type = 0
-        drop_off_type = 0
 
         arrival_time = s.get("atm")
         arrival_day = s.get("ady") or 0
@@ -185,13 +184,9 @@ class LoadSchedules(Task):
         elif arrival_time:
             departure_time = arrival_time
             departure_day = arrival_day
-            # No departure time assumed as disembarking only
-            pickup_type = 1
         elif departure_time:
             arrival_time = departure_time
             arrival_day = departure_day
-            # No arrival time assumed as embarking only
-            drop_off_type = 1
         else:
             self.logger.warning(
                 "Trip %s has no time at stop %d (plk_seq %d)",
@@ -225,6 +220,9 @@ class LoadSchedules(Task):
             "arrival_platform": arr_platform,
             "arrival_track": arr_track,
         }
+
+        pickup_type = int(is_last_stop)
+        drop_off_type = int(is_first_stop)
 
         if (plk_stop_type := s.get("sti")) is not None:
             extra_fields["plk_stop_type"] = str(plk_stop_type)

--- a/polish_trains_gtfs/static/load_schedules.py
+++ b/polish_trains_gtfs/static/load_schedules.py
@@ -172,6 +172,9 @@ class LoadSchedules(Task):
         stop_id = self.get_stop_id(db, s["id"])
         plk_sequence = cast(int, s["ord"])
 
+        pickup_type = 0
+        drop_off_type = 0
+
         arrival_time = s.get("atm")
         arrival_day = s.get("ady") or 0
         departure_time = s.get("dtm")
@@ -182,9 +185,13 @@ class LoadSchedules(Task):
         elif arrival_time:
             departure_time = arrival_time
             departure_day = arrival_day
+            # No departure time assumed as disembarking only
+            pickup_type = 1
         elif departure_time:
             arrival_time = departure_time
             arrival_day = departure_day
+            # No arrival time assumed as embarking only
+            drop_off_type = 1
         else:
             self.logger.warning(
                 "Trip %s has no time at stop %d (plk_seq %d)",
@@ -218,9 +225,6 @@ class LoadSchedules(Task):
             "arrival_platform": arr_platform,
             "arrival_track": arr_track,
         }
-
-        pickup_type = 0
-        drop_off_type = 0
 
         if (plk_stop_type := s.get("sti")) is not None:
             extra_fields["plk_stop_type"] = str(plk_stop_type)


### PR DESCRIPTION
This change extends setting pickup or dropoff type to 1 (no pickup/dropoff available) for the stop times that do not have a departure or arrival time in the PDP API, respectively. This is especially useful for the first or the last stop in a trip, which so far are marked as available for both pickup and dropoff.

Data from PDP for today (14-07-2026) shows that the only stop times in the PDP schedules json that do not have a departure time are either the last in the trip or have stoptypeId equal to 2. The same is true for the arrival time, which is missing only for the first stop or when stoptypeId is 1. Based on that, this PR should not bring any unintended consequences.