### PR TITLE
Adapt deduplicate consecutive times to work on old sqlite

### DIFF
--- a/polish_trains_gtfs/static/deduplicate_consecutive_times.py
+++ b/polish_trains_gtfs/static/deduplicate_consecutive_times.py
@@ -12,11 +12,12 @@ WITH islands AS (
     SELECT
         trip_id,
         stop_sequence,
-        concat_ws(
-            ':',
-            trip_id,
-            stop_id,
-            (row_number() OVER trips - row_number() OVER trip_stops)
+        (
+            trip_id
+            || ':'
+            || stop_id
+            || ':'
+            || CAST((row_number() OVER trips - row_number() OVER trip_stops) AS VARCHAR)
         ) as run_id
     FROM stop_times
     WINDOW


### PR DESCRIPTION
`concat_ws` was added in sqlite version 3.44.0 on 2023-11-01, while still supported Ubuntu 22.04 LTS offers only [3.37.2-2](https://launchpad.net/ubuntu/+source/sqlite3/3.37.2-2). This PR replaces `concat_ws` with more widely available `||` concatenation.